### PR TITLE
Remove deprecated dependency options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
         }
     ],
     "require": {
-        "php": "^7.1|^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "ext-openssl": "*",
-        "guzzlehttp/guzzle": "^6.0|^7.0"
+        "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"


### PR DESCRIPTION
Removing support for older versions of php and guzzle. Should have major bump in version (v2.x) to avoid issues with current live site.